### PR TITLE
accept array as payload, closes #12

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -28,7 +28,7 @@ const Client = class Client extends EventEmitter {
     if (Array.isArray(payload)) {
       payload = new Buffer(payload);
     }
-    if (payload instanceof Buffer) {
+    if (Buffer.isBuffer(payload)) {
       message.payload_raw = payload.toString('base64');
     } else {
       message.payload_fields = payload;

--- a/src/client.js
+++ b/src/client.js
@@ -25,6 +25,9 @@ const Client = class Client extends EventEmitter {
     var message = {
       port: port || 1
     };
+    if (Array.isArray(payload)) {
+      payload = new Buffer(payload);
+    }
     if (payload instanceof Buffer) {
       message.payload_raw = payload.toString('base64');
     } else {


### PR DESCRIPTION
I've chosen to only add support for array to buffer so that people with little familiarity with buffers, can simply think about what bytes to send.

We don't want to encourage `new Buffer(string)`, we don't need `new Buffer(buffer)` because we don't modify it anyway and I don't expect much use of `new Buffer(ArrayBuffer|TypedArray.buffer)`.

And of course anything is still possible, but then just do it before you call `send()`.
