### PR TITLE
Add field/device specific subscribe, closes #9 and closes #8

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
-src/
 node_modules/
+src/
+test/

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ npm run monitor eu hello-world 4rw/vLixroZHch8WNZVBAnmP9GEvuJ1QEB5fI2czlfo=
 }
 ```
 
+## Test
+
+To run the [tests](test):
+
+```bash
+npm install
+npm run test
+```
+
 ## Release Policies
 
 ### Pre-releases

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "description": "The Things Network Client",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "npm run compile && mocha --bail",
     "monitor": "npm run compile && node bin/monitor",
     "compile": "babel src --presets babel-preset-es2015 --out-dir dist",
     "prepublish": "npm run compile",
     "push": "git push --follow-tags"
   },
+  "pre-commit": [
+    "test"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/TheThingsNetwork/node-app-lib.git"
@@ -26,6 +29,9 @@
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",
-    "babel-preset-es2015": "^6.14.0"
+    "babel-preset-es2015": "^6.14.0",
+    "mocha": "^3.0.2",
+    "pre-commit": "^1.1.3",
+    "should": "^11.1.0"
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -69,8 +69,15 @@ const Client = class Client {
 
   _handleMessage(topic, message) {
     var parts = topic.split('/');
+    if (parts[3] !== 'activations' && parts[3] !== 'up') {
+      return;
+    }
     var devId = parts[2];
     var payload = JSON.parse(message.toString());
+    if (parts.length === 4) {
+      payload.app_id = this.appId;
+      payload.dev_id = devId;
+    }
     var data, field;
     switch (parts[3]) {
       case 'activations':

--- a/src/client.js
+++ b/src/client.js
@@ -74,22 +74,12 @@ const Client = class Client {
     }
     var devId = parts[2];
     var payload = JSON.parse(message.toString());
-    if (parts.length === 4) {
+    if (parts.length === 4) { // inject app_id and dev_id, but not for field topics
       payload.app_id = this.appId;
       payload.dev_id = devId;
     }
-    var data, field;
-    switch (parts[3]) {
-      case 'activations':
-        this.ee.emit(topic, devId, payload); // full topic
-        this.ee.emit(parts.slice(0, 2).concat('+', parts.slice(3)).join('/'), devId, payload); // any device
-        break;
-      case 'up':
-        field = (parts.length > 4) ? parts.slice(4).join('/') : null;
-        this.ee.emit(topic, devId, field, payload); // full topic, including field
-        this.ee.emit(parts.slice(0, 2).concat('+', parts.slice(3)).join('/'), devId, field, payload); // any device
-        break;
-    }
+    this.ee.emit(topic, devId, payload); // full topic, including field if any
+    this.ee.emit(parts.slice(0, 2).concat('+', parts.slice(3)).join('/'), devId, payload); // any device
   }
 
   _eventToTopic(eventName, devId, field) {

--- a/src/example.js
+++ b/src/example.js
@@ -7,35 +7,35 @@ var accessKey = '';
 var client = new ttn.Client(region, appId, accessKey);
 
 client.on('connect', function(connack) {
-	console.log('[DEBUG]', 'Connect:', connack);
+  console.log('[DEBUG]', 'Connect:', connack);
 });
 
 client.on('error', function(err) {
-	console.error('[ERROR]', err.message);
+  console.error('[ERROR]', err.message);
 });
 
 client.on('activation', function(data) {
-	console.log('[INFO] ', 'Activation:', data);
+  console.log('[INFO] ', 'Activation:', data);
 });
 
 client.on('message', function(deviceId, field, data) {
-	console.info('[INFO] ', 'Message:', deviceId, field, JSON.stringify(data, null, 2));
+  console.info('[INFO] ', 'Message:', deviceId, field, JSON.stringify(data, null, 2));
 });
 
 client.on('message', null, 'led', function(deviceId, field, data) {
 
-	// Respond to every third message
-	if (data.counter % 3 === 0) {
+  // Respond to every third message
+  if (data.counter % 3 === 0) {
 
-		// Toggle the LED
-		var payload = {
-			led: !!message.led
-		};
+    // Toggle the LED
+    var payload = {
+      led: !!message.led
+    };
 
-		// If you don't have an encoder payload function:
-		// var payload = new Buffer([message.led ? 0 : 1]);
+    // If you don't have an encoder payload function:
+    // var payload = new Buffer([message.led ? 0 : 1]);
 
-		console.log('[DEBUG]', 'Sending:', JSON.stringify(payload));
-		client.send(data.dev_id, payload, data.port);
-	}
+    console.log('[DEBUG]', 'Sending:', JSON.stringify(payload));
+    client.send(data.dev_id, payload, data.port);
+  }
 });

--- a/src/example.js
+++ b/src/example.js
@@ -18,11 +18,11 @@ client.on('activation', function(data) {
 	console.log('[INFO] ', 'Activation:', data);
 });
 
-client.on('message', function(data) {
-	console.info('[INFO] ', 'Message:', JSON.stringify(data, null, 2));
+client.on('message', function(deviceId, field, data) {
+	console.info('[INFO] ', 'Message:', deviceId, field, JSON.stringify(data, null, 2));
 });
 
-client.on('message', function(data) {
+client.on('message', null, 'led', function(deviceId, field, data) {
 
 	// Respond to every third message
 	if (data.counter % 3 === 0) {

--- a/test/client.js
+++ b/test/client.js
@@ -69,6 +69,8 @@ describe('Client', function() {
 				should(data.payload_fields).be.an.Object();
 				should(data.payload_fields.led).be.true();
 				should(data.payload_raw).be.a.String();
+				should(data.app_id).be.a.String().and.equal(client.appId);
+				should(data.dev_id).be.a.String().and.equal('a-device');
 				client.end();
 				done();
 			});

--- a/test/client.js
+++ b/test/client.js
@@ -6,140 +6,142 @@ var BROKER = 'iot.eclipse.org';
 
 describe('Client', function() {
 
-	describe('#new', function() {
-		it('should create client', function() {
-			var client = createClient();
-			client.should.be.an.instanceOf(ttn.Client);
-		});
-	});
+  describe('#new', function() {
+    it('should create client', function() {
+      var client = createClient();
+      client.should.be.an.instanceOf(ttn.Client);
+    });
+  });
 
-	describe('#on(connect)', function() {
-		it('shoudl emit event', function(done) {
-			var client = createClient();
-			client.on('connect', function(connack) {
-				should(connack).be.an.Object();
-				client.end();
-				done();
-			});
-		});
-	});
+  describe('#on(connect)', function() {
+    it('shoudl emit event', function(done) {
+      var client = createClient();
+      client.on('connect', function(connack) {
+        should(connack).be.an.Object();
+        client.end();
+        done();
+      });
+    });
+  });
 
-	describe('#on(activation)', function() {
-		it('should emit event', function(done) {
-			var client = createClient();
-			client.on('activation', function(devId, data) {
-				should(devId).be.a.String().and.equal('a-device');
-				should(data).be.an.Object();
-				should(data.dev_addr).be.a.String().and.equal('26012723');
-				client.end();
-				done();
-			});
-			client.mqtt.publish(client.appId + '/devices/a-device/activations', JSON.stringify({
-				"app_eui": "70B3D57EF000001C",
-				"dev_eui": "0004A30B001B7AD2",
-				"dev_addr": "26012723",
-				"metadata": {
-					"time": "2016-09-13T09:59:02.90329585Z",
-					"frequency": 868.5,
-					"modulation": "LORA",
-					"data_rate": "SF7BW125",
-					"coding_rate": "4/5",
-					"gateways": [{
-						"eui": "B827EBFFFE87BD22",
-						"timestamp": 1484146403,
-						"time": "2016-09-13T09:59:02.867283Z",
-						"channel": 2,
-						"rssi": -49,
-						"snr": 7,
-						"rf_chain": 1
-					}]
-				}
-			}));
-		});
-	});
+  describe('#on(activation)', function() {
+    it('should emit event', function(done) {
+      var client = createClient();
+      client.on('activation', function(devId, data) {
+        should(devId).be.a.String().and.equal('a-device');
+        should(data).be.an.Object();
+        should(data.dev_addr).be.a.String().and.equal('26012723');
+        client.end();
+        done();
+      });
+      client.mqtt.publish(client.appId + '/devices/a-device/activations', JSON.stringify({
+        "app_eui": "70B3D57EF000001C",
+        "dev_eui": "0004A30B001B7AD2",
+        "dev_addr": "26012723",
+        "metadata": {
+          "time": "2016-09-13T09:59:02.90329585Z",
+          "frequency": 868.5,
+          "modulation": "LORA",
+          "data_rate": "SF7BW125",
+          "coding_rate": "4/5",
+          "gateways": [{
+            "eui": "B827EBFFFE87BD22",
+            "timestamp": 1484146403,
+            "time": "2016-09-13T09:59:02.867283Z",
+            "channel": 2,
+            "rssi": -49,
+            "snr": 7,
+            "rf_chain": 1
+          }]
+        }
+      }));
+    });
+  });
 
-	describe('#on(message)', function() {
+  describe('#on(message)', function() {
 
-		it('should emit event', function(done) {
-			var client = createClient();
-			client.on('message', function(devId, data) {
-				should(devId).be.a.String().and.equal('a-device');
-				should(data).be.an.Object();
-				should(data.payload_fields).be.an.Object();
-				should(data.payload_fields.led).be.true();
-				should(data.payload_raw).equal('AQ==');
-				should(data.app_id).be.a.String().and.equal(client.appId);
-				should(data.dev_id).be.a.String().and.equal('a-device');
-				client.end();
-				done();
-			});
-			client.mqtt.publish(client.appId + '/devices/a-device/up', JSON.stringify({
-				"port": 1,
-				"counter": 5,
-				"payload_raw": "AQ==",
-				"payload_fields": {
-					"led": true
-				},
-				"metadata": {
-					"time": "2016-09-14T14:19:20.272552952Z",
-					"frequency": 868.1,
-					"modulation": "LORA",
-					"data_rate": "SF7BW125",
-					"coding_rate": "4/5",
-					"gateways": [{
-						"eui": "B827EBFFFE87BD22",
-						"timestamp": 1960494347,
-						"time": "2016-09-14T14:19:20.258723Z",
-						"rssi": -49,
-						"snr": 9.5,
-						"rf_chain": 1
-					}]
-				}
-			}));
-		});
+    it('should emit event', function(done) {
+      var client = createClient();
+      client.on('message', function(devId, data) {
+        should(devId).be.a.String().and.equal('a-device');
+        should(data).be.an.Object();
+        should(data.payload_fields).be.an.Object();
+        should(data.payload_fields.led).be.true();
+        should(data.payload_raw).equal('AQ==');
+        should(data.app_id).be.a.String().and.equal(client.appId);
+        should(data.dev_id).be.a.String().and.equal('a-device');
+        client.end();
+        done();
+      });
+      client.mqtt.publish(client.appId + '/devices/a-device/up', JSON.stringify({
+        "port": 1,
+        "counter": 5,
+        "payload_raw": "AQ==",
+        "payload_fields": {
+          "led": true
+        },
+        "metadata": {
+          "time": "2016-09-14T14:19:20.272552952Z",
+          "frequency": 868.1,
+          "modulation": "LORA",
+          "data_rate": "SF7BW125",
+          "coding_rate": "4/5",
+          "gateways": [{
+            "eui": "B827EBFFFE87BD22",
+            "timestamp": 1960494347,
+            "time": "2016-09-14T14:19:20.258723Z",
+            "rssi": -49,
+            "snr": 9.5,
+            "rf_chain": 1
+          }]
+        }
+      }));
+    });
 
-		it('should emit event for specific device', function(done) {
-			var client = createClient();
-			client.on('message', 'a-device', function(devId, data) {
-				should(arguments.length).equal(2);
-				should(devId).equal('a-device');
-				should(data).be.an.Object();
-				should(data.payload_raw).equal('AQ==');
-				client.end();
-				done();
-			});
-			client.mqtt.publish(client.appId + '/devices/a-device/up', JSON.stringify({ payload_raw: 'AQ==' }));
-		});
+    it('should emit event for specific device', function(done) {
+      var client = createClient();
+      client.on('message', 'a-device', function(devId, data) {
+        should(arguments.length).equal(2);
+        should(devId).equal('a-device');
+        should(data).be.an.Object();
+        should(data.payload_raw).equal('AQ==');
+        client.end();
+        done();
+      });
+      client.mqtt.publish(client.appId + '/devices/a-device/up', JSON.stringify({
+        payload_raw: 'AQ=='
+      }));
+    });
 
-		it('should emit event for specific device and field', function(done) {
-			var client = createClient();
-			client.on('message', 'a-device', 'led', function(devId, data) {
-				should(arguments.length).equal(2);
-				should(devId).equal('a-device');
-				should(data).be.true();
-				client.end();
-				done();
-			});
-			client.mqtt.publish(client.appId + '/devices/a-device/up/led', JSON.stringify(true));
-		});
+    it('should emit event for specific device and field', function(done) {
+      var client = createClient();
+      client.on('message', 'a-device', 'led', function(devId, data) {
+        should(arguments.length).equal(2);
+        should(devId).equal('a-device');
+        should(data).be.true();
+        client.end();
+        done();
+      });
+      client.mqtt.publish(client.appId + '/devices/a-device/up/led', JSON.stringify(true));
+    });
 
-		it('should emit event for specific field', function(done) {
-			var client = createClient();
-			client.on('message', null, 'led', function(devId, data) {
-				should(arguments.length).equal(2);
-				should(devId).equal('a-device');
-				should(data).be.false();
-				client.end();
-				done();
-			});
-			client.mqtt.publish(client.appId + '/devices/a-device/up/led', JSON.stringify(false));
-		});
+    it('should emit event for specific field', function(done) {
+      var client = createClient();
+      client.on('message', null, 'led', function(devId, data) {
+        should(arguments.length).equal(2);
+        should(devId).equal('a-device');
+        should(data).be.false();
+        client.end();
+        done();
+      });
+      client.mqtt.publish(client.appId + '/devices/a-device/up/led', JSON.stringify(false));
+    });
 
-	});
+  });
 });
 
 function createClient() {
-	client = new ttn.Client(BROKER); // don't pass appId and appAccessKey to the test broker
-	client.appId = Math.floor(Math.random() * 16777215).toString(16); // but set random appId afterwards
-	return client;
+  client = new ttn.Client(BROKER); // don't pass appId and appAccessKey to the test broker
+  client.appId = Math.floor(Math.random() * 16777215).toString(16); // but set random appId afterwards
+  return client;
 }

--- a/test/client.js
+++ b/test/client.js
@@ -1,0 +1,136 @@
+var should = require('should');
+
+var ttn = require('..');
+
+var BROKER = 'iot.eclipse.org';
+
+describe('Client', function() {
+
+	describe('#new', function() {
+		it('should create client', function() {
+			var client = createClient();
+			client.should.be.an.instanceOf(ttn.Client);
+		});
+	});
+
+	describe('#on(connect)', function() {
+		it('shoudl emit event', function(done) {
+			var client = createClient();
+			client.on('connect', function(connack) {
+				should(connack).be.an.Object();
+				client.end();
+				done();
+			});
+		});
+	});
+
+	describe('#on(activation)', function() {
+		it('should emit event', function(done) {
+			var client = createClient();
+			client.on('activation', function(devId, data) {
+				should(devId).be.a.String().and.equal('a-device');
+				should(data).be.an.Object();
+				should(data.dev_addr).be.a.String().and.equal('26012723');
+				client.end();
+				done();
+			});
+			client.mqtt.publish(client.appId + '/devices/a-device/activations', JSON.stringify({
+				"app_eui": "70B3D57EF000001C",
+				"dev_eui": "0004A30B001B7AD2",
+				"dev_addr": "26012723",
+				"metadata": {
+					"time": "2016-09-13T09:59:02.90329585Z",
+					"frequency": 868.5,
+					"modulation": "LORA",
+					"data_rate": "SF7BW125",
+					"coding_rate": "4/5",
+					"gateways": [{
+						"eui": "B827EBFFFE87BD22",
+						"timestamp": 1484146403,
+						"time": "2016-09-13T09:59:02.867283Z",
+						"channel": 2,
+						"rssi": -49,
+						"snr": 7,
+						"rf_chain": 1
+					}]
+				}
+			}));
+		});
+	});
+
+	describe('#on(message)', function() {
+
+		it('should emit event', function(done) {
+			var client = createClient();
+			client.on('message', function(devId, field, data) {
+				should(devId).be.a.String().and.equal('a-device');
+				should(field === null).be.true();
+				should(data).be.an.Object();
+				should(data.payload_fields).be.an.Object();
+				should(data.payload_fields.led).be.true();
+				should(data.payload_raw).be.a.String();
+				client.end();
+				done();
+			});
+			client.mqtt.publish(client.appId + '/devices/a-device/up', JSON.stringify({
+				"port": 1,
+				"counter": 5,
+				"payload_raw": "AQ==",
+				"payload_fields": {
+					"led": true
+				},
+				"metadata": {
+					"time": "2016-09-14T14:19:20.272552952Z",
+					"frequency": 868.1,
+					"modulation": "LORA",
+					"data_rate": "SF7BW125",
+					"coding_rate": "4/5",
+					"gateways": [{
+						"eui": "B827EBFFFE87BD22",
+						"timestamp": 1960494347,
+						"time": "2016-09-14T14:19:20.258723Z",
+						"rssi": -49,
+						"snr": 9.5,
+						"rf_chain": 1
+					}]
+				}
+			}));
+		});
+
+		it('should emit event for specific device', function(done) {
+			var client = createClient();
+			client.on('message', 'a-device', function(devId, field, data) {
+				client.end();
+				done();
+			});
+			client.mqtt.publish(client.appId + '/devices/a-device/up', JSON.stringify({}));
+		});
+
+		it('should emit event for specific device and field', function(done) {
+			var client = createClient();
+			client.on('message', 'a-device', 'led', function(devId, field, data) {
+				should(data).be.true();
+				client.end();
+				done();
+			});
+			client.mqtt.publish(client.appId + '/devices/a-device/up/led', JSON.stringify(true));
+		});
+
+		it('should emit event for specific field', function(done) {
+			var client = createClient();
+			client.on('message', null, 'led', function(devId, field, data) {
+				should(data).be.false();
+				client.end();
+				done();
+			});
+			client.mqtt.publish(client.appId + '/devices/a-device/up/led', JSON.stringify(false));
+		});
+
+	});
+});
+
+function createClient() {
+	client = new ttn.Client(BROKER); // don't pass appId and appAccessKey to the test broker
+	client.appId = Math.floor(Math.random() * 16777215).toString(16); // but set random appId afterwards
+	return client;
+}

--- a/test/client.js
+++ b/test/client.js
@@ -62,13 +62,12 @@ describe('Client', function() {
 
 		it('should emit event', function(done) {
 			var client = createClient();
-			client.on('message', function(devId, field, data) {
+			client.on('message', function(devId, data) {
 				should(devId).be.a.String().and.equal('a-device');
-				should(field === null).be.true();
 				should(data).be.an.Object();
 				should(data.payload_fields).be.an.Object();
 				should(data.payload_fields.led).be.true();
-				should(data.payload_raw).be.a.String();
+				should(data.payload_raw).equal('AQ==');
 				should(data.app_id).be.a.String().and.equal(client.appId);
 				should(data.dev_id).be.a.String().and.equal('a-device');
 				client.end();
@@ -101,16 +100,22 @@ describe('Client', function() {
 
 		it('should emit event for specific device', function(done) {
 			var client = createClient();
-			client.on('message', 'a-device', function(devId, field, data) {
+			client.on('message', 'a-device', function(devId, data) {
+				should(arguments.length).equal(2);
+				should(devId).equal('a-device');
+				should(data).be.an.Object();
+				should(data.payload_raw).equal('AQ==');
 				client.end();
 				done();
 			});
-			client.mqtt.publish(client.appId + '/devices/a-device/up', JSON.stringify({}));
+			client.mqtt.publish(client.appId + '/devices/a-device/up', JSON.stringify({ payload_raw: 'AQ==' }));
 		});
 
 		it('should emit event for specific device and field', function(done) {
 			var client = createClient();
-			client.on('message', 'a-device', 'led', function(devId, field, data) {
+			client.on('message', 'a-device', 'led', function(devId, data) {
+				should(arguments.length).equal(2);
+				should(devId).equal('a-device');
 				should(data).be.true();
 				client.end();
 				done();
@@ -120,7 +125,9 @@ describe('Client', function() {
 
 		it('should emit event for specific field', function(done) {
 			var client = createClient();
-			client.on('message', null, 'led', function(devId, field, data) {
+			client.on('message', null, 'led', function(devId, data) {
+				should(arguments.length).equal(2);
+				should(devId).equal('a-device');
 				should(data).be.false();
 				client.end();
 				done();

--- a/test/mqtt.js
+++ b/test/mqtt.js
@@ -1,0 +1,46 @@
+var should = require('should');
+
+var mqtt = require('mqtt');
+
+var TOPIC = Math.floor(Math.random() * 16777215).toString(16);
+
+describe('MQTT', function() {
+	var client;
+
+	describe('#connect', function() {
+		it('create client', function() {
+			client = mqtt.connect('mqtt://test.mosquitto.org');
+		});
+	});
+
+	describe('#on(connect)', function() {
+		it('should emit event', function(done) {
+			client.on('connect', function(connack) {
+				should(connack).be.an.Object();
+				done();
+			});
+		});
+	});
+
+	describe('#subscribe', function() {
+		it('should subscribe', function() {
+			client.subscribe(TOPIC);
+		});
+	});
+
+	describe('#publish', function() {
+		it('should publish', function() {
+			client.publish(TOPIC, 'Hello, World!');
+		});
+	});
+
+	describe('#on(message)', function() {
+		it('should emit event', function(done) {
+			client.on('message', function(topic, message) {
+				should(message.toString()).be.a.String().equal('Hello, World!');
+				client.end();
+				done();
+			});
+		});
+	});
+});

--- a/test/mqtt.js
+++ b/test/mqtt.js
@@ -5,42 +5,42 @@ var mqtt = require('mqtt');
 var TOPIC = Math.floor(Math.random() * 16777215).toString(16);
 
 describe('MQTT', function() {
-	var client;
+  var client;
 
-	describe('#connect', function() {
-		it('create client', function() {
-			client = mqtt.connect('mqtt://test.mosquitto.org');
-		});
-	});
+  describe('#connect', function() {
+    it('create client', function() {
+      client = mqtt.connect('mqtt://test.mosquitto.org');
+    });
+  });
 
-	describe('#on(connect)', function() {
-		it('should emit event', function(done) {
-			client.on('connect', function(connack) {
-				should(connack).be.an.Object();
-				done();
-			});
-		});
-	});
+  describe('#on(connect)', function() {
+    it('should emit event', function(done) {
+      client.on('connect', function(connack) {
+        should(connack).be.an.Object();
+        done();
+      });
+    });
+  });
 
-	describe('#subscribe', function() {
-		it('should subscribe', function() {
-			client.subscribe(TOPIC);
-		});
-	});
+  describe('#subscribe', function() {
+    it('should subscribe', function() {
+      client.subscribe(TOPIC);
+    });
+  });
 
-	describe('#publish', function() {
-		it('should publish', function() {
-			client.publish(TOPIC, 'Hello, World!');
-		});
-	});
+  describe('#publish', function() {
+    it('should publish', function() {
+      client.publish(TOPIC, 'Hello, World!');
+    });
+  });
 
-	describe('#on(message)', function() {
-		it('should emit event', function(done) {
-			client.on('message', function(topic, message) {
-				should(message.toString()).be.a.String().equal('Hello, World!');
-				client.end();
-				done();
-			});
-		});
-	});
+  describe('#on(message)', function() {
+    it('should emit event', function(done) {
+      client.on('message', function(topic, message) {
+        should(message.toString()).be.a.String().equal('Hello, World!');
+        client.end();
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Closes #9 and #8

This also introduces Mocha/Should tests that run before every commit.

For the new API of `on('message')` and `on('activation')` see the [client test](https://github.com/TheThingsNetwork/node-app-lib/pull/18/files#diff-7e3bd8e7059a21bfd255649cbfc84b33R61)

~~Also, `dev_id` and `app_id` are no longer added to the payload since the callbacks now get these via arguments.~~ > Re-added to not break #2 / #19
