### PR TITLE
Add support for device events, closes #26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "6"
+  - "4"

--- a/API.md
+++ b/API.md
@@ -25,31 +25,31 @@ var client = new ttn.Client(region, appId, appAccessKey);
 Emitted on successful (re)connection.
 
 ```js
-client.on('connect', function(connack) {});
+client.on('connect', function cb(connack) {});
 ```
 
-* `connack [object]`: Connack packet. See [MQTT](https://www.npmjs.com/package/mqtt#event-connect).
+* `cb.connack [object]`: Connack packet. See [MQTT](https://www.npmjs.com/package/mqtt#event-connect).
 
 ## Event: error
 
 Emitted when the client cannot connect or when a parsing error occurs.
 
 ```js
-client.on('error', function(err) {});
+client.on('error', function cb(err) {});
 ```
 
-* `err [Error]`: Error object. See [MQTT](https://www.npmjs.com/package/mqtt#event-error).
+* `cb.err [Error]`: Error object. See [MQTT](https://www.npmjs.com/package/mqtt#event-error).
 
 ## Event: message
 
 Emitted when TTN forwards a message addressed to your application.
 
 ```js
-client.on('message', function(deviceId, data) {});
+client.on('message', function cb(deviceId, data) {});
 ```
 
-* `deviceId [string]`: Device ID, e.g.: `my-uno`.
-* `data [object]`: Message data, e.g.:
+* `cb.deviceId [string]`: Device ID, e.g.: `my-uno`.
+* `cb.data [object]`: Message data, e.g.:
 
   ```json
   {
@@ -86,28 +86,26 @@ client.on('message', function(deviceId, data) {});
 ### Listen for a specific device
 
 ```js
-client.on('message', 'my-uno', function(deviceId, data) {});
+client.on('message', 'my-uno', function cb(deviceId, data) {});
 ```
 
 ### Listen for a specific field (and device)
 
 ```js
-client.on('message', null, 'led', function(deviceId, data) {});
+client.on('message', [deviceId], 'led', function cb(deviceId, data) {});
 ```
-
-*  `deviceId [string]`: Device ID, e.g. `my-uno`
-*  `data [mixed]`: Message data, e.g. `true`
 
 ## Event: activation
 
 Emitted when a device registered to the application activates.
 
 ```js
-client.on('activation', deviceId, function(deviceId, data)) {});
+client.on('activation', [deviceId], function cb(deviceId, data)) {});
 ```
 
-* `deviceId [string]`: Device ID, e.g.: `my-uno`.
-* `data [object]`: Activation data, e.g.:
+* `deviceId [string]`: Optional device ID to filter on, e.g.: `my-uno`.
+* `cb.deviceId [string]`: Device ID, e.g.: `my-uno`.
+* `cb.data [object]`: Activation data, e.g.:
 
   ```json
   {
@@ -139,12 +137,13 @@ client.on('activation', deviceId, function(deviceId, data)) {});
 Emitted when a device event is published.
 
 ```js
-client.on('device', deviceId, event, function(deviceId, data)) {});
+client.on('device', [deviceId], event, function cb(deviceId, data)) {});
 ```
 
-* `deviceId [string]`: Device ID, e.g.: `my-uno`.
+* `deviceId [string]`: Optional device ID to filter on, e.g.: `my-uno`.
 * `event [string]`: Event name, e.g.: `activations` or `down/scheduled`.
-* `data [object]`: Event data, e.g. for `down/scheduled`:
+* `cb.deviceId [string]`: Device ID, e.g.: `my-uno`.
+* `cb.data [object]`: Event data, e.g. for `down/scheduled`:
 
   ```json
   {
@@ -176,7 +175,7 @@ client.send(deviceId, payload, [port]);
     
         > This requires your application to be configured with an encoder payload function to encode the object in bytes.
         
-*  `port [number]`: Port to send via. Default: `1`.
+*  `port [number]`: Optional port to address. Default: `1`.
 
 > See the [Node.js Buffer reference](https://nodejs.org/api/buffer.html#buffer_class_buffer) for different ways to create a buffer. The client will call [`Buffer.toString('base64')`](https://nodejs.org/api/buffer.html#buffer_buf_tostring_encoding_start_end) before publishing the message to The Things Network's MQTT broker.
 

--- a/API.md
+++ b/API.md
@@ -40,46 +40,6 @@ client.on('error', function(err) {});
 
 * `err [Error]`: Error object. See [MQTT](https://www.npmjs.com/package/mqtt#event-error).
 
-## Event: activation
-
-Emitted when a device registered to the application activates.
-
-```js
-client.on('activation', deviceId, function(data)) {});
-```
-
-* `deviceId [string]`: Device ID, e.g.: `my-uno`.
-* `data [object]`: Activation data, e.g.:
-
-  ```json
-  {
-    "app_eui": "70B3D57ED0000AFB",
-    "dev_eui": "0004A30B001B7AD2",
-    "dev_addr": "260023BB",
-    "metadata": {
-      "time": "2016-09-07T12:43:17.97454032Z",
-      "frequency": 867.1,
-      "modulation": "LORA",
-      "data_rate": "SF7BW125",
-      "coding_rate": "4/5",
-      "gateways": [{
-        "eui": "0000024B08060112",
-        "timestamp": 3546311603,
-        "time": "2016-09-07T12:43:17.938537Z",
-        "channel": 2,
-        "rssi": -107,
-        "snr": 1.2
-      }]
-    }
-  }
-  ```
-
-### Listen for a specific device
-
-```js
-client.on('activation', 'my-uno', function(deviceId, data) {});
-```
-
 ## Event: message
 
 Emitted when TTN forwards a message addressed to your application.
@@ -95,7 +55,12 @@ client.on('message', function(deviceId, data) {});
   {
     "port": 1,
     "counter": 10,
-    "payload_raw": "AQ==",
+    "payload_raw": {
+      "type": "Buffer",
+      "data": [
+        1
+      ]
+    },
     "payload_fields": {
       "led": true
     },
@@ -132,6 +97,68 @@ client.on('message', null, 'led', function(deviceId, data) {});
 
 *  `deviceId [string]`: Device ID, e.g. `my-uno`
 *  `data [mixed]`: Message data, e.g. `true`
+
+## Event: activation
+
+Emitted when a device registered to the application activates.
+
+```js
+client.on('activation', deviceId, function(deviceId, data)) {});
+```
+
+* `deviceId [string]`: Device ID, e.g.: `my-uno`.
+* `data [object]`: Activation data, e.g.:
+
+  ```json
+  {
+    "app_eui": "70B3D57ED0000AFB",
+    "dev_eui": "0004A30B001B7AD2",
+    "dev_addr": "260023BB",
+    "metadata": {
+      "time": "2016-09-07T12:43:17.97454032Z",
+      "frequency": 867.1,
+      "modulation": "LORA",
+      "data_rate": "SF7BW125",
+      "coding_rate": "4/5",
+      "gateways": [{
+        "eui": "0000024B08060112",
+        "timestamp": 3546311603,
+        "time": "2016-09-07T12:43:17.938537Z",
+        "channel": 2,
+        "rssi": -107,
+        "snr": 1.2
+      }]
+    }
+  }
+  ```
+  
+> The `activation` is a type of `device` event and internally mapped as such.
+
+## Event: device
+
+Emitted when a device event is published.
+
+```js
+client.on('device', deviceId, event, function(deviceId, data)) {});
+```
+
+* `deviceId [string]`: Device ID, e.g.: `my-uno`.
+* `event [string]`: Event name, e.g.: `activations` or `down/scheduled`.
+* `data [object]`: Event data, e.g. for `down/scheduled`:
+
+  ```json
+  {
+    "port": 1,
+    "payload_raw": {
+      "type": "Buffer",
+      "data": [
+        1
+      ]
+    }
+  }
+  ```
+  
+> The `activation` is a type of `device` event and internally mapped as such.
 
 ## Method: send
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# The Things Network Node.js Client [![NPM](https://img.shields.io/npm/v/ttn.svg?maxAge=2592000)](https://www.npmjs.com/package/ttn)
+# The Things Network Node.js Client
+[![Build Status](https://travis-ci.org/TheThingsNetwork/node-app-lib.svg?branch=master)](https://travis-ci.org/TheThingsNetwork/node-app-lib) [![NPM](https://img.shields.io/npm/v/ttn.svg?maxAge=2592000)](https://www.npmjs.com/package/ttn)
 
 This is the Node.js client for [The Things Network](https://www.thethingsnetwork.org) to receive activations and messages from IoT devices via The Things Network and send messages as well.
 
-## Installation
+## Installation [![NPM](https://img.shields.io/npm/v/ttn.svg?maxAge=2592000)](https://www.npmjs.com/package/ttn)
 
 ```bash
 npm install --save ttn
@@ -23,7 +24,7 @@ An [example](src/example.js) is included and can be run directly in the browser 
 > var ttn = require('ttn@2.0.0-5');
 > ```
 
-## Test
+## Test [![Build Status](https://travis-ci.org/TheThingsNetwork/node-app-lib.svg?branch=master)](https://travis-ci.org/TheThingsNetwork/node-app-lib)
 
 To run the [tests](test):
 
@@ -31,55 +32,3 @@ To run the [tests](test):
 npm install
 npm test
 ```
-
-## Release Policies
-
-### Pre-releases
-If you'd like to do a pre-release this is how it works.
-
-1.  Bump package [version](https://docs.npmjs.com/cli/version) and add git tag:
-
-	- For the first pre-release of a version:
-
-		```bash
-		npm version pre[patch|minor|major]
-		```
-		
-	- For consecutive pre-releases of the same version:
-
-		```bash
-		npm version prerelease
-		```
-	
-2.	[Publish](https://docs.npmjs.com/cli/publish) to a pre-release stream (aka npm tag), e.g. `refactor`
-
-	```bash
-	npm publish --tag refactor
-	```
-	
-3. [Push](https://git-scm.com/docs/git-push) commits, including tags:
-
-	```bash
-	npm run push
-	```
-
-### Releases
-
-1. Bump package [version](https://docs.npmjs.com/cli/version) and add git tag:
-
-	```bash
-	npm version [patch|minor|major]
-	```
-	
-	> **NOTE:** If the current version is a pre-release all of the above will simply remove the pre-release identifier. For example, if the current version is `2.0.0-4` then `npm version patch` will result in `2.0.0` and not `2.0.1`.
-
-2. [Publish](https://docs.npmjs.com/cli/publish) package:
-
-	```bash
-	npm publish
-	```
-3. [Push](https://git-scm.com/docs/git-push) commits, including tags:
-
-	```bash
-	git push --follow-tags
-	```

--- a/src/example.js
+++ b/src/example.js
@@ -18,6 +18,10 @@ client.on('activation', function(deviceId, data) {
   console.log('[INFO] ', 'Activation:', deviceId, JSON.stringify(data, null, 2));
 });
 
+client.on('device', null, 'down/scheduled', function(deviceId, data) {
+  console.log('[INFO] ', 'Scheduled:', deviceId, JSON.stringify(data, null, 2));
+});
+
 client.on('message', function(deviceId, data) {
   console.info('[INFO] ', 'Message:', deviceId, JSON.stringify(data, null, 2));
 });


### PR DESCRIPTION
The API (also see updated README):

``` js
client.on('device', deviceId, event, function(deviceId, data)) {});
```

Internally, the `activation` event now maps to:

``` js
client.on('device', deviceId, 'activations', function(deviceId, data)) {});
```

Tests included.

**Note:** Once app events are there, we can add:

``` js
client.on('app', event, function(data)) {});
```
