### PR TITLE
Add map of valid regions and validate them

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2,22 +2,30 @@ const mqtt = require('mqtt');
 const util = require('util');
 const EventEmitter = require('events');
 
-const regions = {
-  'eu': 'eu',
-  'asia-se': 'asia-se',
-  'brazil': 'brazil',
-  'us-west': 'us-west',
-};
+const regions = [ 'eu', 'asia-se', 'brazil', 'us-west' ].reduce(function (acc, region) {
+  acc[region] = region.concat('.thethings.network');
+  return acc;
+}, {});
+
+const ttnSuffix = /\.thethings\.network$/;
 
 const Client = class Client {
   constructor(region, appId, appAccessKey, options = {}) {
 
-    const reg = reg.replace && reg.replace(/\.thethings\.network$/, '')
-    if (!(reg in regions)) {
-      throw new Error('Invalid region \'' + region + '\'');
+    let reg = region
+
+
+    // get the region from regions if it exists
+    if (region in regions) {
+      reg = regions[region]
     }
 
-    this.url = util.format('mqtt://%s', reg + '.thethings.network');
+    // validate the things network regions
+    if (ttnSuffix.test(reg) && !(reg.replace(ttnSuffix, '') in regions)) {
+      throw new Error('Invalid The Things Network region \'' + region + '\'');
+    }
+
+    this.url = util.format('mqtt://%s', reg)
     this.appId = appId;
     this.ee = new EventEmitter();
     options.username = appId;

--- a/src/client.js
+++ b/src/client.js
@@ -12,12 +12,11 @@ const ttnSuffix = /\.thethings\.network$/;
 const Client = class Client {
   constructor(region, appId, appAccessKey, options = {}) {
 
-    let reg = region
-
+    let reg = region;
 
     // get the region from regions if it exists
     if (region in regions) {
-      reg = regions[region]
+      reg = regions[region];
     }
 
     // validate the things network regions
@@ -25,7 +24,7 @@ const Client = class Client {
       throw new Error('Invalid The Things Network region \'' + region + '\'');
     }
 
-    this.url = util.format('mqtt://%s', reg)
+    this.url = util.format('mqtt://%s', reg);
     this.appId = appId;
     this.ee = new EventEmitter();
     options.username = appId;

--- a/src/client.js
+++ b/src/client.js
@@ -1,28 +1,11 @@
 const mqtt = require('mqtt');
 const util = require('util');
 const EventEmitter = require('events');
-
-const regions = [ 'eu', 'asia-se', 'brazil', 'us-west' ].reduce(function (acc, region) {
-  acc[region] = region.concat('.thethings.network');
-  return acc;
-}, {});
-
-const ttnSuffix = /\.thethings\.network$/;
+const regions = require('./regions');
 
 const Client = class Client {
   constructor(region, appId, appAccessKey, options = {}) {
-
-    let reg = region;
-
-    // get the region from regions if it exists
-    if (region in regions) {
-      reg = regions[region];
-    }
-
-    // validate the things network regions
-    if (ttnSuffix.test(reg) && !(reg.replace(ttnSuffix, '') in regions)) {
-      throw new Error('Invalid The Things Network region \'' + region + '\'');
-    }
+    var reg = regions.validate(region);
 
     this.url = util.format('mqtt://%s', reg);
     this.appId = appId;
@@ -146,5 +129,4 @@ const Client = class Client {
   }
 };
 
-Client.regions = regions;
 module.exports = Client;

--- a/src/client.js
+++ b/src/client.js
@@ -2,9 +2,22 @@ const mqtt = require('mqtt');
 const util = require('util');
 const EventEmitter = require('events');
 
+const regions = {
+  'eu': 'eu',
+  'asia-se': 'asia-se',
+  'brazil': 'brazil',
+  'us-west': 'us-west',
+};
+
 const Client = class Client {
   constructor(region, appId, appAccessKey, options = {}) {
-    this.url = util.format('mqtt://%s', (region.indexOf('.') !== -1) ? region : region + '.thethings.network');
+
+    const reg = reg.replace && reg.replace(/\.thethings\.network$/, '')
+    if (!(reg in regions)) {
+      throw new Error('Invalid region \'' + region + '\'');
+    }
+
+    this.url = util.format('mqtt://%s', reg + '.thethings.network');
     this.appId = appId;
     this.ee = new EventEmitter();
     options.username = appId;
@@ -126,4 +139,5 @@ const Client = class Client {
   }
 };
 
+Client.regions = regions;
 module.exports = Client;

--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,6 @@
 const Client = require('./client');
 
 module.exports = {
-  Client: Client
+  Client: Client,
+  regions: Client.reqions
 };

--- a/src/index.js
+++ b/src/index.js
@@ -4,5 +4,5 @@ const Client = require('./client');
 
 module.exports = {
   Client: Client,
-  regions: Client.reqions
+  regions: Client.regions,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const Client = require('./client');
+const regions = require('./regions');
 
 module.exports = {
   Client: Client,
-  regions: Client.regions,
+  regions: regions.regions,
 };

--- a/src/regions.js
+++ b/src/regions.js
@@ -1,0 +1,29 @@
+
+const regions = [ 'eu', 'asia-se', 'brazil', 'us-west' ].reduce(function (acc, region) {
+  acc[region] = region.concat('.thethings.network');
+  return acc;
+}, {});
+
+const ttnSuffix = /\.thethings\.network$/;
+
+const validate = function (region) {
+  let reg = region;
+
+  // get the region from regions if it exists
+  if (region in regions) {
+    reg = regions[region];
+  }
+
+  // validate the things network regions
+  if (ttnSuffix.test(reg) && !(reg.replace(ttnSuffix, '') in regions)) {
+    throw new Error('Invalid The Things Network region \'' + region + '\'');
+  }
+
+  return reg
+};
+
+module.exports = {
+  validate: validate,
+  regions: regions,
+};
+

--- a/test/client.js
+++ b/test/client.js
@@ -15,6 +15,26 @@ describe('Client', function () {
       var client = createClient();
       client.should.be.an.instanceOf(ttn.Client);
     });
+
+    it('should create a client with a string region (eg \'eu\')', function () {
+      new ttn.Client('eu');
+    });
+
+    it('should create a client with a string region (eg \'eu\')', function () {
+      new ttn.Client(ttn.Client.regions.eu);
+    });
+
+    it('should create a client with a raw url to a broker', function () {
+      new ttn.Client('localhost');
+      new ttn.Client('rabbitmq');
+      new ttn.Client('foo.bar.com');
+    });
+
+    it('should not create a client with an invalid ttn region', function () {
+      (function () {
+        new ttn.Client('invalid.thethings.network');
+      }).should.throw(/Invalid The Things Network region/);
+    })
   });
 
   describe('#on(connect)', function () {

--- a/test/client.js
+++ b/test/client.js
@@ -34,7 +34,7 @@ describe('Client', function () {
       (function () {
         new ttn.Client('invalid.thethings.network');
       }).should.throw(/Invalid The Things Network region/);
-    })
+    });
   });
 
   describe('#on(connect)', function () {

--- a/test/client.js
+++ b/test/client.js
@@ -15,27 +15,8 @@ describe('Client', function () {
       var client = createClient();
       client.should.be.an.instanceOf(ttn.Client);
     });
-
-    it('should create a client with a string region (eg \'eu\')', function () {
-      new ttn.Client('eu');
-    });
-
-    it('should create a client with a string region (eg \'eu\')', function () {
-      new ttn.Client(ttn.Client.regions.eu);
-    });
-
-    it('should create a client with a raw url to a broker', function () {
-      new ttn.Client('localhost');
-      new ttn.Client('rabbitmq');
-      new ttn.Client('foo.bar.com');
-    });
-
-    it('should not create a client with an invalid ttn region', function () {
-      (function () {
-        new ttn.Client('invalid.thethings.network');
-      }).should.throw(/Invalid The Things Network region/);
-    });
   });
+
 
   describe('#on(connect)', function () {
     it('shoudl emit event', function (done) {

--- a/test/regions.js
+++ b/test/regions.js
@@ -1,0 +1,26 @@
+var should = require('should');
+var regions = require('../dist/regions');
+var ttn = require('..');
+
+describe('Regions', function () {
+  it('should create a client with a string region (eg \'eu\')', function () {
+    should(regions.validate('eu')).equal('eu.thethings.network');
+  });
+
+  it('should create a client with a string region (eg \'eu\')', function () {
+    should(regions.validate(ttn.regions.eu)).equal(ttn.regions.eu)
+  });
+
+  it('should create a client with a raw url to a broker', function () {
+    should(regions.validate('localhost')).equal('localhost');
+    should(regions.validate('rabbitmq')).equal('rabbitmq');
+    should(regions.validate('foo.bar.com')).equal('foo.bar.com');
+  });
+
+  it('should not create a client with an invalid ttn region', function () {
+    (function () {
+      regions.validate('invalid.thethings.network')
+    }).should.throw(/Invalid The Things Network region/);
+  });
+});
+


### PR DESCRIPTION
Validates regions based on a preset map of valid regions and exposes these regions so users don't have to use magic strings.

`Client.regions['us-west']` is more sensible than `'us-west'`.
