### PR TITLE
feature: AccountClient (#73)

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -8,7 +8,19 @@
 -   [setup](#setup)
 -   [PayloadFunctions](#payloadfunctions)
 -   [open](#open)
--   [DiscoveryOptions](#discoveryoptions)
+-   [AccountClient](#accountclient)
+    -   [getAllApplications](#getallapplications)
+    -   [getApplication](#getapplication)
+    -   [createApplication](#createapplication)
+    -   [deleteApplication](#deleteapplication)
+    -   [addCollaborator](#addcollaborator)
+    -   [deleteCollaborator](#deletecollaborator)
+    -   [addEUI](#addeui)
+    -   [deleteEUI](#deleteeui)
+-   [HandlerClient](#handlerclient)
+    -   [open](#open-1)
+    -   [data](#data)
+    -   [application](#application-1)
 -   [ApplicationClient](#applicationclient)
     -   [constructor](#constructor)
     -   [get](#get)
@@ -21,19 +33,8 @@
     -   [device](#device)
     -   [updateDevice](#updatedevice)
     -   [deleteDevice](#deletedevice)
--   [HandlerClient](#handlerclient)
-    -   [open](#open-1)
-    -   [data](#data)
-    -   [application](#application-1)
--   [AccountClient](#accountclient)
-    -   [getAllApplications](#getallapplications)
-    -   [getApplication](#getapplication)
-    -   [createApplication](#createapplication)
-    -   [deleteApplication](#deleteapplication)
-    -   [addCollaborator](#addcollaborator)
-    -   [deleteCollaborator](#deletecollaborator)
-    -   [addEUI](#addeui)
-    -   [deleteEUI](#deleteeui)
+    -   [getEUIs](#geteuis)
+-   [DiscoveryOptions](#discoveryoptions)
 -   [ApplicationSettings](#applicationsettings)
 -   [DataClient](#dataclient)
     -   [constructor](#constructor-1)
@@ -133,15 +134,141 @@ Type: {decoder: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript
 
 Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[HandlerClient](#handlerclient)>** 
 
-## DiscoveryOptions
+## AccountClient
 
-Type: {address: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?, insecure: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, certificate: ([Buffer](https://nodejs.org/api/buffer.html) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?}
+`Account` is a client for The Things Network account server API.
+It can be used to manage applications and their EUIs, as well as gateways.
+Either a Bearer Token or an Application Access Key can be used for
+authentication. The latter method allows to use the `getApplication()`
+function only.
 
-**Properties**
+Example:
 
--   `address` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
--   `insecure` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** 
--   `certificate` **([Buffer](https://nodejs.org/api/buffer.html) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?** 
+    const account = new Account("accesKeyOrToken", "https://customserveradress.org")
+
+**Parameters**
+
+-   `accessKeyOrToken` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `serverAddress` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)**  (optional, default `"https://account.thethingsnetwork.org"`)
+
+### getAllApplications
+
+Gets metadata about all applications that are accessible with
+the given accessToken
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[AccountApplication](#accountapplication)>>** 
+
+### getApplication
+
+Gets the information that is stored about a given application.
+This includes the EUIs, name access keys, collaborators.
+The properties that can be retrieved depend on the rights of
+the used authorization mechanism.
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[AccountApplication](#accountapplication)>** 
+
+### createApplication
+
+Creates a new application on the account server.
+
+**Parameters**
+
+-   `app` **[MinimalAccApplication](#minimalaccapplication)** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
+
+### deleteApplication
+
+Removes an application from the account server.
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
+
+### addCollaborator
+
+Adds a collaborator with a set of access rights to the given application.
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `collaborator` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `rights` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[AppAccessRights](#appaccessrights)>** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
+
+### deleteCollaborator
+
+Removes a collaborator by her username from an application
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `collaborator` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
+
+### addEUI
+
+Adds an EUI to the given application. Must be hexadecimal with a length of 16.
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `eui` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
+
+### deleteEUI
+
+Removes an EUI from the given application.
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `eui` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
+
+## HandlerClient
+
+`Handler` is a  client for The Things Network handler APIs.
+It can be used to get data from an application or to manage devices.
+
+Example:
+
+    const handler = new Handler("my-app-id", "my-app-access-key")
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `appAccessKey` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `opts` **[DiscoveryOptions](#discoveryoptions)?** 
+
+### open
+
+`open` opens the client to the handler.
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[HandlerClient](#handlerclient)>** 
+
+### data
+
+Open a data client that can be used to receive live application data
+
+Returns **[DataClient](#dataclient)** 
+
+### application
+
+Open a application manager that can be used to manage the settings and devices of the
+application.
+
+Returns **[ApplicationClient](#applicationclient)** 
 
 ## ApplicationClient
 
@@ -259,141 +386,21 @@ Delete the specified device.
 
 Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** 
 
-## HandlerClient
+### getEUIs
 
-`Handler` is a  client for The Things Network handler APIs.
-It can be used to get data from an application or to manage devices.
+Returns the EUI(s) for this application from the account server.
 
-Example:
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>>** 
 
-    const handler = new Handler("my-app-id", "my-app-access-key")
+## DiscoveryOptions
 
-**Parameters**
+Type: {address: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?, insecure: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, certificate: ([Buffer](https://nodejs.org/api/buffer.html) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?}
 
--   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `appAccessKey` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `opts` **[DiscoveryOptions](#discoveryoptions)?** 
+**Properties**
 
-### open
-
-`open` opens the client to the handler.
-
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[HandlerClient](#handlerclient)>** 
-
-### data
-
-Open a data client that can be used to receive live application data
-
-Returns **[DataClient](#dataclient)** 
-
-### application
-
-Open a application manager that can be used to manage the settings and devices of the
-application.
-
-Returns **[ApplicationClient](#applicationclient)** 
-
-## AccountClient
-
-`Account` is a client for The Things Network account server API.
-It can be used to manage applications and their EUIs, as well as gateways.
-Either a Bearer Token or an Application Access Key can be used for
-authentication. The latter method allows to use the `getApplication()`
-function only.
-
-Example:
-
-    const account = new Account("accesKeyOrToken", "https://customserveradress.org")
-
-**Parameters**
-
--   `accessKeyOrToken` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `serverAddress` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)**  (optional, default `"https://account.thethingsnetwork.org"`)
-
-### getAllApplications
-
-Gets metadata about all applications that are accessible with
-the given accessToken
-
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[AccountApplication](#accountapplication)>>** 
-
-### getApplication
-
-Gets the information that is stored about a given application.
-This includes the EUIs, name access keys, collaborators.
-The properties that can be retrieved depend on the rights of
-the used authorization mechanism.
-
-**Parameters**
-
--   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[AccountApplication](#accountapplication)>** 
-
-### createApplication
-
-Creates a new application on the account server.
-
-**Parameters**
-
--   `app` **[MinimalAccApplication](#minimalaccapplication)** 
-
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
-
-### deleteApplication
-
-Removes an application from the account server.
-
-**Parameters**
-
--   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
-
-### addCollaborator
-
-Adds a collaborator with a set of access rights to the given application.
-
-**Parameters**
-
--   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `collaborator` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `rights` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[AppAccessRights](#appaccessrights)>** 
-
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
-
-### deleteCollaborator
-
-Removes a collaborator by her username from an application
-
-**Parameters**
-
--   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `collaborator` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
-
-### addEUI
-
-Adds an EUI to the given application. Must be hexadecimal with a length of 16.
-
-**Parameters**
-
--   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `eui` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
-
-### deleteEUI
-
-Removes an EUI from the given application.
-
-**Parameters**
-
--   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
--   `eui` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
-
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
+-   `address` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+-   `insecure` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** 
+-   `certificate` **([Buffer](https://nodejs.org/api/buffer.html) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?** 
 
 ## ApplicationSettings
 
@@ -554,13 +561,13 @@ Type: (`"router"` \| `"broker"` \| `"handler"`)
 
 Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[ApplicationClient](#applicationclient)>** 
 
-## 
-
-Settings for the discovery server
-
 ## app
 
 The app used for testing
+
+## 
+
+Settings for the discovery server
 
 ## Announcement
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -8,6 +8,7 @@
 -   [setup](#setup)
 -   [PayloadFunctions](#payloadfunctions)
 -   [open](#open)
+-   [DiscoveryOptions](#discoveryoptions)
 -   [ApplicationClient](#applicationclient)
     -   [constructor](#constructor)
     -   [get](#get)
@@ -20,11 +21,19 @@
     -   [device](#device)
     -   [updateDevice](#updatedevice)
     -   [deleteDevice](#deletedevice)
--   [DiscoveryOptions](#discoveryoptions)
 -   [HandlerClient](#handlerclient)
     -   [open](#open-1)
     -   [data](#data)
     -   [application](#application-1)
+-   [AccountClient](#accountclient)
+    -   [getAllApplications](#getallapplications)
+    -   [getApplication](#getapplication)
+    -   [createApplication](#createapplication)
+    -   [deleteApplication](#deleteapplication)
+    -   [addCollaborator](#addcollaborator)
+    -   [deleteCollaborator](#deletecollaborator)
+    -   [addEUI](#addeui)
+    -   [deleteEUI](#deleteeui)
 -   [ApplicationSettings](#applicationsettings)
 -   [DataClient](#dataclient)
     -   [constructor](#constructor-1)
@@ -33,20 +42,24 @@
     -   [on](#on)
     -   [off](#off)
     -   [send](#send)
--   [application](#application-2)
 -   [Service](#service)
+-   [application](#application-2)
 -   [app](#app)
 -   [Announcement](#announcement)
 -   [data](#data-1)
+-   [account](#account)
 -   [Discovery](#discovery)
     -   [constructor](#constructor-2)
     -   [getAll](#getall)
     -   [get](#get-1)
     -   [getByAppID](#getbyappid)
+-   [AppAccessRights](#appaccessrights)
 -   [services](#services)
     -   [Handler](#handler)
     -   [Router](#router)
     -   [Broker](#broker)
+-   [MinimalAccApplication](#minimalaccapplication)
+-   [AccountApplication](#accountapplication)
 
 ## Application
 
@@ -119,6 +132,16 @@ Type: {decoder: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript
 -   `tokenOrKey`  The Access Token or Access Key used to authenticate.
 
 Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[HandlerClient](#handlerclient)>** 
+
+## DiscoveryOptions
+
+Type: {address: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?, insecure: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, certificate: ([Buffer](https://nodejs.org/api/buffer.html) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?}
+
+**Properties**
+
+-   `address` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+-   `insecure` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** 
+-   `certificate` **([Buffer](https://nodejs.org/api/buffer.html) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?** 
 
 ## ApplicationClient
 
@@ -236,16 +259,6 @@ Delete the specified device.
 
 Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;void>** 
 
-## DiscoveryOptions
-
-Type: {address: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?, insecure: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, certificate: ([Buffer](https://nodejs.org/api/buffer.html) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?}
-
-**Properties**
-
--   `address` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
--   `insecure` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** 
--   `certificate` **([Buffer](https://nodejs.org/api/buffer.html) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?** 
-
 ## HandlerClient
 
 `Handler` is a  client for The Things Network handler APIs.
@@ -279,6 +292,108 @@ Open a application manager that can be used to manage the settings and devices o
 application.
 
 Returns **[ApplicationClient](#applicationclient)** 
+
+## AccountClient
+
+`Account` is a client for The Things Network account server API.
+It can be used to manage applications and their EUIs, as well as gateways.
+Either a Bearer Token or an Application Access Key can be used for
+authentication. The latter method allows to use the `getApplication()`
+function only.
+
+Example:
+
+    const account = new Account("accesKeyOrToken", "https://customserveradress.org")
+
+**Parameters**
+
+-   `accessKeyOrToken` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `serverAddress` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)**  (optional, default `"https://account.thethingsnetwork.org"`)
+
+### getAllApplications
+
+Gets metadata about all applications that are accessible with
+the given accessToken
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[AccountApplication](#accountapplication)>>** 
+
+### getApplication
+
+Gets the information that is stored about a given application.
+This includes the EUIs, name access keys, collaborators.
+The properties that can be retrieved depend on the rights of
+the used authorization mechanism.
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[AccountApplication](#accountapplication)>** 
+
+### createApplication
+
+Creates a new application on the account server.
+
+**Parameters**
+
+-   `app` **[MinimalAccApplication](#minimalaccapplication)** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
+
+### deleteApplication
+
+Removes an application from the account server.
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
+
+### addCollaborator
+
+Adds a collaborator with a set of access rights to the given application.
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `collaborator` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `rights` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[AppAccessRights](#appaccessrights)>** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
+
+### deleteCollaborator
+
+Removes a collaborator by her username from an application
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `collaborator` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
+
+### addEUI
+
+Adds an EUI to the given application. Must be hexadecimal with a length of 16.
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `eui` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
+
+### deleteEUI
+
+Removes an EUI from the given application.
+
+**Parameters**
+
+-   `appID` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `eui` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;any>** 
 
 ## ApplicationSettings
 
@@ -420,6 +535,13 @@ Send a downlink message to the device with the specified device ID.
 -   `confirmed` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Set to true for confirmed downlink.
 -   `schedule` **Schedule** Set to the scheduling you want to use (first, last or replace).
 
+## Service
+
+Service is an enum of the possible services types to get from the discovery
+server.
+
+Type: (`"router"` \| `"broker"` \| `"handler"`)
+
 ## application
 
 `application` creates and opens an ApplicationClient for the application with the specified ID.
@@ -431,13 +553,6 @@ Send a downlink message to the device with the specified device ID.
 -   `opts` **[DiscoveryOptions](#discoveryoptions)?** 
 
 Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[ApplicationClient](#applicationclient)>** 
-
-## Service
-
-Service is an enum of the possible services types to get from the discovery
-server.
-
-Type: (`"router"` \| `"broker"` \| `"handler"`)
 
 ## 
 
@@ -483,6 +598,17 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 ## 
 
 Settings for the handler
+
+## account
+
+`account` creates an AccountClient for the user associated to the specified key or token.
+
+**Parameters**
+
+-   `accessKeyOrToken` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The Access Token or Access Key used to authenticate
+-   `serverAddress` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The URL to the account server to use. Defaults to "<https://account.thethingsnetwork.org>"
+
+Returns **[AccountClient](#accountclient)** 
 
 ## Discovery
 
@@ -536,6 +662,12 @@ It looks up the handler the application is registered to.
 
 Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Announcement](#announcement)>** 
 
+## AppAccessRights
+
+AppAccessRights
+
+Type: (`"settings"` \| `"delete"` \| `"collaborators"` \| `"devices"` \| `"messages:up:r"` \| `"messages:up:w"` \| `"messages:down:w"`)
+
 ## services
 
 services is a map with the known service names for the discovery server.
@@ -553,3 +685,23 @@ Router is a Router service
 ### Broker
 
 Broker is a Broker service
+
+## MinimalAccApplication
+
+The minimal payload for to the POST /applications route
+of the account server
+
+Type: {id: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), name: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)}
+
+**Properties**
+
+-   `id` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+## AccountApplication
+
+AccountApplication contains the metadata of an application
+returned by the account server. Presence of optional fields
+depends on the [access rights](#appaccessrights) of the used accessKey / -token.
+
+Type: any

--- a/README.md
+++ b/README.md
@@ -86,3 +86,11 @@ To build the repository and transpile to ES5, run:
 make build
 ```
 
+## Install git hooks
+
+To avoid checking in code with type- and linter-errors, install commit hooks via
+
+```
+make git.hooks
+```
+

--- a/examples/account.js
+++ b/examples/account.js
@@ -1,0 +1,69 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+// @flow
+
+import { account } from "../src"
+
+// insert your own values
+const appID = "foo"
+const accessKey = "ttn-account.eiPq8mEeYRL_PNBZsOpPy-O3ABJXYWulODmQGR5PZzg"
+const accessToken = ""
+
+const main = async function () {
+  // you can connect through a JSON Web Token for the full account,
+  // or via an Access Key for a single application. The latter method only
+  // works for a subset of queries (GET operations on the given application)
+  // to aquire them, see https://www.thethingsnetwork.org/docs/network/account/authentication.html
+  const clientJWToken = account(accessToken)
+  const clientAppKey = account(accessKey)
+
+  // 1) show all applications that can be accessed with this key
+  const allApps = await clientJWToken.getAllApplications()
+  const allApps2 = await clientAppKey.getAllApplications()
+
+  console.log(`${allApps.length} apps on this account.`)
+  console.log(`only ${allApps2.length} app (${allApps2[0].id}) accessible through this access key.`)
+
+  // 2) get the EUIs of the app, which can be used to register devices using the ApplicationManagerClient
+  let myApp = await clientAppKey.getApplication(appID)
+  console.log(myApp.euis)
+
+  // the following methods require a JWT with correct access rights!
+
+  // 3) create a new app
+  const newAppID = "mynewcustomapp"
+  const newApp = {
+    id: newAppID,
+    name: "this is a test app",
+  }
+
+  await clientJWToken.createApplication(newApp)
+  console.log(await clientJWToken.getApplication(newApp.id))
+
+  // 4) add an EUI to the app
+  await clientJWToken.addEUI(newApp.id, "0011223344556677")
+  myApp = await clientJWToken.getApplication(newApp.id)
+  console.log(myApp)
+
+  // 5) add a collaborator to the app
+  await clientJWToken.addCollaborator(newApp.id, "username", [
+    // "settings",
+    // "delete",
+    // "collaborators",
+    "devices",
+    "messages:up:r",
+    "messages:up:w",
+    "messages:down:w",
+  ])
+
+  console.log(await clientJWToken.getApplication(newApp.id))
+
+  // 6) delete the test app again
+  await clientJWToken.deleteApplication(newApp.id)
+}
+
+main().catch(function (err) {
+  console.error(err)
+  process.exit(1)
+})

--- a/examples/application.js
+++ b/examples/application.js
@@ -24,10 +24,15 @@ const main = async function () {
   const app = await application.get()
   console.log(app)
 
+  // additional information (name, EUIs) is stored on the Account Server,
+  // so we need to retrieve this information separately.
+  // there is a shorthand for an application to get the EUIs:
+  const euis = await application.getEUIs()
+
   // register a new device
   await application.registerDevice("foo", {
     description: "Description",
-    appEui: "0011223344556677",
+    appEui: euis[0],
     devEui: "9988776655443322",
     devAddr: "11223344",
     nwkSKey: key(16),

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "grpc": "^1.4.1",
     "jsonwebtoken": "^7.4.1",
     "mqtt": "^2.9.1",
+    "request-promise-native": "^1.0.5",
     "source-map-support": "^0.4.17",
     "ttnapi": "https://github.com/thethingsnetwork/api"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grpc": "^1.4.1",
     "jsonwebtoken": "^7.4.1",
     "mqtt": "^2.9.1",
-    "request-promise-native": "^1.0.5",
+    "node-fetch": "^1.7.3",
     "source-map-support": "^0.4.17",
     "ttnapi": "https://github.com/thethingsnetwork/api"
   },

--- a/src/account/account.js
+++ b/src/account/account.js
@@ -1,0 +1,119 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+// @flow
+
+import request from "request-promise-native"
+
+import { MODERN_CIPHER_SUITES } from "../utils"
+import isToken from "../utils/is-token"
+
+// Necessary to make gRPC work
+process.env.GRPC_SSL_CIPHER_SUITES = MODERN_CIPHER_SUITES
+
+/**
+ * `Account` is a client for The Things Network account server API.
+ * It can be used to manage applications and their EUIs, as well as gateways.
+ * Either a Bearer Token or an Application Access Key can be used for
+ * authentication. The latter method allows to use the `getApplication()`
+ * function only.
+ *
+ * Example:
+ * ```
+ * const account = new Account("accesKeyOrToken", "https://customserveradress.org")
+ * ```
+ */
+export class AccountClient {
+  /** @private */
+  authHeader : string
+
+  /** @private */
+  serverAddress: string
+
+  constructor (accessKeyOrToken : string, serverAddress : string = "https://account.thethingsnetwork.org") : void {
+    this.authHeader = isToken(accessKeyOrToken)
+      ? `Bearer ${accessKeyOrToken}`
+      : `Key ${accessKeyOrToken}`
+
+    this.serverAddress = serverAddress
+  }
+
+  /** @private */
+  async makeRequest (url : string, method : string = "GET", body : ?any) : Promise<any> {
+    return await request({
+      method,
+      url: `${this.serverAddress}/${url}`,
+      headers: { Authorization: this.authHeader },
+      json: true,
+      body,
+    })
+  }
+
+  async getAllApplications () : Promise<Array<Application>> {
+    return await this.makeRequest("applications")
+  }
+
+  /**
+   * Gets the information that is stored about a given application.
+   * This includes the EUIs, name access keys, collaborators.
+   * The properties that can be retrieved depend on the rights of
+   * the used authorization mechanism.
+   */
+  async getApplication (appID : string) : Promise<Application> {
+    return await this.makeRequest(`applications/${appID}`)
+  }
+
+  async createApplication (app : MinimalApplication) : Promise<any> {
+    return await this.makeRequest("applications", "POST", app)
+  }
+
+  async deleteApplication (appID : string) : Promise<any> {
+    return await this.makeRequest(`applications/${appID}`, "DELETE")
+  }
+
+  async addCollaborator (appID : string, collaborator : string, rights : Array<AccessRights>) : Promise<any> {
+    return await this.makeRequest(`applications/${appID}/collaborators/${collaborator}`, "PUT", rights)
+  }
+
+  async deleteCollaborator (appID : string, collaborator : string) : Promise<any> {
+    return await this.makeRequest(`applications/${appID}/collaborators/${collaborator}`, "DELETE")
+  }
+
+  async addEUI (appID : string, eui : string) : Promise<any> {
+    return await this.makeRequest(`applications/${appID}/euis/${eui}`, "PUT")
+  }
+
+  async deleteEUI (appID : string, eui : string) : Promise<any> {
+    return await this.makeRequest(`applications/${appID}/euis/${eui}`, "DELETE")
+  }
+}
+
+type AccessRights = "settings"
+  | "delete"
+  | "collaborators"
+  | "devices"
+  | "messages:up:r"
+  | "messages:up:w"
+  | "messages:down:w"
+
+type MinimalApplication = {
+  id: string,
+  name: string,
+}
+
+type Application = MinimalApplication & {
+  euis: Array<string>,
+  created: string,
+  rights: Array<string>,
+  collaborators?: Array<{
+    username: string,
+    email: string,
+    rights: Array<string>,
+  }>,
+  access_keys?: Array<{
+    name: string,
+    key: string,
+    rights: Array<string>,
+  }>,
+  deleted?: string
+}

--- a/src/account/account.js
+++ b/src/account/account.js
@@ -3,7 +3,7 @@
 
 // @flow
 
-import request from "request-promise-native"
+import fetch from "node-fetch"
 
 import { MODERN_CIPHER_SUITES } from "../utils"
 import isToken from "../utils/is-token"
@@ -40,17 +40,21 @@ export class AccountClient {
 
   /** @private */
   async makeRequest (url : string, method : string = "GET", body : ?any) : Promise<any> {
-    return await request({
+    const res = await fetch(`${this.serverAddress}/${url}`, {
       method,
-      url: `${this.serverAddress}/${url}`,
-      headers: { Authorization: this.authHeader },
-      json: true,
       body,
+      headers: { Authorization: this.authHeader },
     })
+
+    if (res.status >= 400) {
+      throw new Error(`${res.status} ${res.statusText}`)
+    }
+
+    return res.json()
   }
 
-  async getAllApplications () : Promise<Array<Application>> {
-    return await this.makeRequest("applications")
+  getAllApplications () : Promise<Array<Application>> {
+    return this.makeRequest("applications")
   }
 
   /**
@@ -59,32 +63,32 @@ export class AccountClient {
    * The properties that can be retrieved depend on the rights of
    * the used authorization mechanism.
    */
-  async getApplication (appID : string) : Promise<Application> {
-    return await this.makeRequest(`applications/${appID}`)
+  getApplication (appID : string) : Promise<Application> {
+    return this.makeRequest(`applications/${appID}`)
   }
 
-  async createApplication (app : MinimalApplication) : Promise<any> {
-    return await this.makeRequest("applications", "POST", app)
+  createApplication (app : MinimalApplication) : Promise<any> {
+    return this.makeRequest("applications", "POST", app)
   }
 
-  async deleteApplication (appID : string) : Promise<any> {
-    return await this.makeRequest(`applications/${appID}`, "DELETE")
+  deleteApplication (appID : string) : Promise<any> {
+    return this.makeRequest(`applications/${appID}`, "DELETE")
   }
 
-  async addCollaborator (appID : string, collaborator : string, rights : Array<AccessRights>) : Promise<any> {
-    return await this.makeRequest(`applications/${appID}/collaborators/${collaborator}`, "PUT", rights)
+  addCollaborator (appID : string, collaborator : string, rights : Array<AccessRights>) : Promise<any> {
+    return this.makeRequest(`applications/${appID}/collaborators/${collaborator}`, "PUT", rights)
   }
 
-  async deleteCollaborator (appID : string, collaborator : string) : Promise<any> {
-    return await this.makeRequest(`applications/${appID}/collaborators/${collaborator}`, "DELETE")
+  deleteCollaborator (appID : string, collaborator : string) : Promise<any> {
+    return this.makeRequest(`applications/${appID}/collaborators/${collaborator}`, "DELETE")
   }
 
-  async addEUI (appID : string, eui : string) : Promise<any> {
-    return await this.makeRequest(`applications/${appID}/euis/${eui}`, "PUT")
+  addEUI (appID : string, eui : string) : Promise<any> {
+    return this.makeRequest(`applications/${appID}/euis/${eui}`, "PUT")
   }
 
-  async deleteEUI (appID : string, eui : string) : Promise<any> {
-    return await this.makeRequest(`applications/${appID}/euis/${eui}`, "DELETE")
+  deleteEUI (appID : string, eui : string) : Promise<any> {
+    return this.makeRequest(`applications/${appID}/euis/${eui}`, "DELETE")
   }
 }
 

--- a/src/account/account.js
+++ b/src/account/account.js
@@ -53,7 +53,11 @@ export class AccountClient {
     return res.json()
   }
 
-  getAllApplications () : Promise<Array<Application>> {
+  /**
+   * Gets metadata about all applications that are accessible with
+   * the given accessToken
+   */
+  getAllApplications () : Promise<Array<AccountApplication>> {
     return this.makeRequest("applications")
   }
 
@@ -63,36 +67,57 @@ export class AccountClient {
    * The properties that can be retrieved depend on the rights of
    * the used authorization mechanism.
    */
-  getApplication (appID : string) : Promise<Application> {
+  getApplication (appID : string) : Promise<AccountApplication> {
     return this.makeRequest(`applications/${appID}`)
   }
 
-  createApplication (app : MinimalApplication) : Promise<any> {
+  /**
+   * Creates a new application on the account server.
+   */
+  createApplication (app : MinimalAccApplication) : Promise<any> {
     return this.makeRequest("applications", "POST", app)
   }
 
+  /**
+   * Removes an application from the account server.
+   */
   deleteApplication (appID : string) : Promise<any> {
     return this.makeRequest(`applications/${appID}`, "DELETE")
   }
 
-  addCollaborator (appID : string, collaborator : string, rights : Array<AccessRights>) : Promise<any> {
+  /**
+   * Adds a collaborator with a set of access rights to the given application.
+   */
+  addCollaborator (appID : string, collaborator : string, rights : Array<AppAccessRights>) : Promise<any> {
     return this.makeRequest(`applications/${appID}/collaborators/${collaborator}`, "PUT", rights)
   }
 
+  /**
+   * Removes a collaborator by her username from an application
+   */
   deleteCollaborator (appID : string, collaborator : string) : Promise<any> {
     return this.makeRequest(`applications/${appID}/collaborators/${collaborator}`, "DELETE")
   }
 
+  /**
+   * Adds an EUI to the given application. Must be hexadecimal with a length of 16.
+   */
   addEUI (appID : string, eui : string) : Promise<any> {
     return this.makeRequest(`applications/${appID}/euis/${eui}`, "PUT")
   }
 
+  /**
+   * Removes an EUI from the given application.
+   */
   deleteEUI (appID : string, eui : string) : Promise<any> {
     return this.makeRequest(`applications/${appID}/euis/${eui}`, "DELETE")
   }
 }
 
-type AccessRights = "settings"
+/**
+ * AppAccessRights
+ */
+type AppAccessRights = "settings"
   | "delete"
   | "collaborators"
   | "devices"
@@ -100,12 +125,21 @@ type AccessRights = "settings"
   | "messages:up:w"
   | "messages:down:w"
 
-type MinimalApplication = {
+/**
+ * The minimal payload for to the POST /applications route
+ * of the account server
+ */
+type MinimalAccApplication = {
   id: string,
   name: string,
 }
 
-type Application = MinimalApplication & {
+/**
+ * AccountApplication contains the metadata of an application
+ * returned by the account server. Presence of optional fields
+ * depends on the [access rights](#appaccessrights) of the used accessKey / -token.
+ */
+type AccountApplication = MinimalAccApplication & {
   euis: Array<string>,
   created: string,
   rights: Array<string>,

--- a/src/account/account.js
+++ b/src/account/account.js
@@ -42,8 +42,11 @@ export class AccountClient {
   async makeRequest (url : string, method : string = "GET", body : ?any) : Promise<any> {
     const res = await fetch(`${this.serverAddress}/${url}`, {
       method,
-      body,
-      headers: { Authorization: this.authHeader },
+      body: JSON.stringify(body),
+      headers: {
+        authorization: this.authHeader,
+        "content-type": "application/json",
+      },
     })
 
     if (res.status >= 400) {

--- a/src/account/index.js
+++ b/src/account/index.js
@@ -1,0 +1,6 @@
+// Copyright © 2017 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+// @flow
+
+export { AccountClient } from "./account"

--- a/src/applications/applications.js
+++ b/src/applications/applications.js
@@ -301,6 +301,9 @@ export class ApplicationClient {
     return req
   }
 
+  /**
+   * Returns the EUI(s) for this application from the account server.
+   */
   async getEUIs () : Promise<Array<string>> {
     const appInfo = await this.accountClient.getApplication(this.appID)
 

--- a/src/applications/applications.js
+++ b/src/applications/applications.js
@@ -4,6 +4,7 @@
 // @flow
 
 import grpc from "grpc"
+import request from "request-promise-native"
 
 import proto from "ttnapi/handler/handler_pb"
 import lorawan from "ttnapi/protocol/lorawan/device_pb"
@@ -293,5 +294,17 @@ export class ApplicationClient {
     }
 
     return req
+  }
+
+  async getEUIs (accountServer : string = "https://account.thethingsnetwork.org") {
+    const authHeader = this.appAccessKey
+      ? `Key ${this.appAccessKey}`
+      : `Bearer ${this.appAccessToken}`
+
+    return await request({
+      url: `${accountServer}/applications/${this.appID}/euis`,
+      headers: { Authorization: authHeader },
+      json: true,
+    })
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
 // @flow
 
 import { HandlerClient } from "./handler"
+import { AccountClient } from "./account"
 import { ApplicationClient } from "./applications"
 import { DataClient } from "./data"
 import type { DiscoveryOptions } from "./discovery"
@@ -47,4 +48,14 @@ export const application = async function (appID : string, accessKeyOrToken : st
 export const data = async function (appID : string, accessKeyOrToken : string, opts : ?DiscoveryOptions) : Promise<DataClient> {
   const handler = await open(appID, accessKeyOrToken, opts)
   return handler.data()
+}
+
+/**
+ * `account` creates an AccountClient for the user associated to the specified key or token.
+ *
+ * @param accessKeyOrToken  - The Access Token or Access Key used to authenticate
+ * @param serverAddress  - The URL to the account server to use. Defaults to "https://account.thethingsnetwork.org"
+ */
+export const account = function (accessKeyOrToken : string, serverAddress? : string) : AccountClient {
+  return new AccountClient(accessKeyOrToken, serverAddress)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,6 +1702,12 @@ emoji-regex@^6.0.0:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.4.3.tgz#6ac2ac58d4b78def5e39b33fcbf395688af3076c"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
 end-of-stream@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.0.0.tgz#d4596e702734a93e40e9af864319eabd99ff2f0e"
@@ -2520,6 +2526,10 @@ iconv-lite@0.4.13:
 iconv-lite@^0.4.17:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
+
+iconv-lite@~0.4.13:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
 ignore@^3.3.3:
   version "3.3.3"
@@ -3374,7 +3384,7 @@ lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3629,6 +3639,13 @@ natural-compare@^1.4.0:
 netrc@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
+
+node-fetch@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4331,20 +4348,6 @@ replace-ext@1.0.0, replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
-request-promise-core@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
-  dependencies:
-    lodash "^4.13.1"
-
-request-promise-native@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
-  dependencies:
-    request-promise-core "1.1.1"
-    stealthy-require "^1.1.0"
-    tough-cookie ">=2.3.3"
-
 request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
@@ -4589,10 +4592,6 @@ sshpk@^1.7.0:
 state-toggle@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.0.tgz#d20f9a616bb4f0c3b98b91922d25b640aa2bc425"
-
-stealthy-require@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
 stream-array@^1.1.0:
   version "1.1.2"
@@ -4839,12 +4838,6 @@ topo@1.x.x:
   resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
   dependencies:
     hoek "2.x.x"
-
-tough-cookie@>=2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
-  dependencies:
-    punycode "^1.4.1"
 
 tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3374,7 +3374,7 @@ lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4331,6 +4331,20 @@ replace-ext@1.0.0, replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
+
 request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
@@ -4575,6 +4589,10 @@ sshpk@^1.7.0:
 state-toggle@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.0.tgz#d20f9a616bb4f0c3b98b91922d25b640aa2bc425"
+
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
 stream-array@^1.1.0:
   version "1.1.2"
@@ -4821,6 +4839,12 @@ topo@1.x.x:
   resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
   dependencies:
     hoek "2.x.x"
+
+tough-cookie@>=2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
+  dependencies:
+    punycode "^1.4.1"
 
 tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"


### PR DESCRIPTION
Adds a client for the Account Server that is exposed as `ttn.account()`.
A meaningful subset of the routes (targeting the management of applications) is implemented.

Additionally, a shorthand is added to the `ApplicationClient`: `app.getEUIs()` (#73)