### PR TITLE
expose disconnect event from mqtt

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -457,7 +457,7 @@ Same as close (for backwards compatibility).
 
 Starts listening to events.
 
-Possible events are:
+Possible events (application messages):
 
 -   `uplink` (or `message`): Messages sent by the devices to the appliction.
 -   `activation`: An alias for the `activations` (see `event`)
@@ -476,6 +476,14 @@ Possible events are:
 
 See [The MQTT API Reference](https://www.thethingsnetwork.org/docs/applications/mqtt/api.html)
 for more information about these events and what their payloads look like.
+
+MQTT connection events:
+
+-   `error`: An error occured / the initial connection failed.
+-   `connect`: A connection to the MQTT broker was established.
+-   `disconnect`: The connection to the MQTT broker was lost.
+-   `reconnect`: A reconnect to the MQTT broker is attempted.
+-   `close`: A connection (attempt) failed.
 
 **Parameters**
 


### PR DESCRIPTION
The `close` and `reconnect` events that are exposed in the mqtt data client are not very useful:
They are fired each time..
- a reconnection is attempted (eg every second), 
- a (re-)connection failed

To be notified **once** about a loss of connectivity, there is the [`offline` event](https://github.com/mqttjs/MQTT.js#event-offline), which i exposed as `disconnect` for consistency.