### PR TITLE
Add method to get device address

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -21,6 +21,7 @@
     -   [open](#open-1)
     -   [data](#data)
     -   [application](#application-1)
+-   [DiscoveryOptions](#discoveryoptions)
 -   [ApplicationClient](#applicationclient)
     -   [constructor](#constructor)
     -   [get](#get)
@@ -34,7 +35,7 @@
     -   [updateDevice](#updatedevice)
     -   [deleteDevice](#deletedevice)
     -   [getEUIs](#geteuis)
--   [DiscoveryOptions](#discoveryoptions)
+    -   [getDeviceAddress](#getdeviceaddress)
 -   [ApplicationSettings](#applicationsettings)
 -   [DataClient](#dataclient)
     -   [constructor](#constructor-1)
@@ -270,6 +271,16 @@ application.
 
 Returns **[ApplicationClient](#applicationclient)** 
 
+## DiscoveryOptions
+
+Type: {address: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?, insecure: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, certificate: ([Buffer](https://nodejs.org/api/buffer.html) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?}
+
+**Properties**
+
+-   `address` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+-   `insecure` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** 
+-   `certificate` **([Buffer](https://nodejs.org/api/buffer.html) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?** 
+
 ## ApplicationClient
 
 A client that manages devices on the handler.
@@ -392,15 +403,15 @@ Returns the EUI(s) for this application from the account server.
 
 Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>>** 
 
-## DiscoveryOptions
+### getDeviceAddress
 
-Type: {address: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?, insecure: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?, certificate: ([Buffer](https://nodejs.org/api/buffer.html) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?}
+Return a device address for the given constraints.
 
-**Properties**
+**Parameters**
 
--   `address` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
--   `insecure` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** 
--   `certificate` **([Buffer](https://nodejs.org/api/buffer.html) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))?** 
+-   `usage` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Usage>** The list for wich the address will be used.
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Buffer](https://nodejs.org/api/buffer.html)>** address - A buffer containing the address.
 
 ## ApplicationSettings
 

--- a/src/applications/applications.test.js
+++ b/src/applications/applications.test.js
@@ -149,3 +149,9 @@ test("ApplicationClient devices management", async () => {
   expect(after).toHaveLength(0)
 })
 
+test("ApplicationClient getDeviceAddress()", async () => {
+  const client = new ApplicationClient(stubs.app.appId, stubs.app.accessToken, stubs.handlerAddress, stubs.handler.certificate)
+
+  const addr = await client.getDeviceAddress()
+  expect(addr).not.toBeUndefined()
+})


### PR DESCRIPTION
Adds a method to get device addresses for specific utilities from the handler.
  
`getDeviceAddress([ "abp" ])`